### PR TITLE
Update Sympy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = {
         'astunparse==1.6.3',
         'numpy==1.22.3',
         'scipy==1.8.0',
-        'sympy==1.6',
+        'sympy==1.10.1',
     ],
     'magics' : [
         'graphviz==0.13.2',

--- a/src/poly.py
+++ b/src/poly.py
@@ -8,7 +8,7 @@ from math import isinf
 
 import sympy
 
-from sympy.calculus.util import limit
+from sympy import limit
 
 from .sets import EmptySet
 from .sets import ExtReals

--- a/src/transforms.py
+++ b/src/transforms.py
@@ -9,10 +9,10 @@ from math import isinf
 
 import sympy
 
+from sympy import limit
 from sympy.abc import X as symX
 
 from sympy.calculus.util import function_range
-from sympy.calculus.util import limit
 
 from .math_util import isinf_neg
 from .math_util import isinf_pos


### PR DESCRIPTION
### What does this do?

Updates Sympy and changes the import of `limit` (as this seems to have moved in the later versions of Sympy).

### Why do we want this? 
Newer versions of Nix packages are required for installations on ARM Macs. These newer packages are not compatible with the old version of Sympy.

### How was this tested?
Tested by running:
```
$ python3 -m  pip install .
$ pytest tests/
